### PR TITLE
Add "History" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ An official ☄️ Effector SWC Plugin for SSR and easier debugging experience i
 - [Installation and versioning](https://effector.dev/api/effector/swc-plugin/#installation)
 - [Configuration reference](https://effector.dev/api/effector/swc-plugin/#configuration)
 - [Contributing guide](https://github.com/effector/swc-plugin/blob/master/CONTRIBUTING.md)
+
+### 📝 History
+
+This project was previously known as the community plugin [`effector-swc-plugin`](https://www.npmjs.com/package/effector-swc-plugin/). It has now been officially adopted as the primary version by the Effector team.
+
+The [previous version](https://github.com/effector/swc-plugin-legacy/), which had stability issues, has been replaced by this improved and reliable release.


### PR DESCRIPTION
This clarifies that this plugin is an up-to-date version, compared to the [previous iteration](https://github.com/effector/swc-plugin-legacy).