### PR TITLE
Improve relative factories handling

### DIFF
--- a/.changeset/four-laws-prove.md
+++ b/.changeset/four-laws-prove.md
@@ -1,0 +1,5 @@
+---
+"@effector/swc-plugin": patch
+---
+
+Improve relative factories handling

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,14 @@ use swc_core::{
         ast::*,
         visit::{as_folder, Fold, VisitMut, VisitMutWith},
     },
-    plugin::{
-        metadata::TransformPluginMetadataContextKind, plugin_transform,
-        proxies::TransformPluginProgramMetadata,
-    },
+    plugin::{plugin_transform, proxies::TransformPluginProgramMetadata},
 };
 
-use crate::visitors::{analyzer, force_scope, unit_identifier};
 pub use crate::{config::Config, visitors::VisitorMeta};
+use crate::{
+    utils::path::filename_from_meta,
+    visitors::{analyzer, force_scope, unit_identifier},
+};
 
 mod config;
 mod constants;
@@ -54,9 +54,7 @@ pub fn process_transform(
     .expect("effector-plugin config should be valid");
 
     let meta = VisitorMeta {
-        file: meta
-            .get_context(&TransformPluginMetadataContextKind::Filename)
-            .unwrap_or("unknown".into()),
+        file: filename_from_meta(&meta).unwrap_or("unknown.js".into()),
 
         config: Rc::new(config),
         mapper: Lrc::from(meta.source_map),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,5 +3,5 @@ pub use self::{keyof::*, path::Resolve, uobject::UObject};
 
 mod keyof;
 mod method;
-mod path;
+pub(crate) mod path;
 mod uobject;

--- a/src/visitors/analyzer.rs
+++ b/src/visitors/analyzer.rs
@@ -46,18 +46,13 @@ impl Analyzer {
                 .resolve();
 
             // Only custom factories define relative paths
-            for factory in self
+            return self
                 .config
                 .factories
                 .iter()
                 .filter(|factory| factory.starts_with("./"))
-            {
-                if Path::new(factory).resolve() == import_path {
-                    return true;
-                };
-            }
-
-            return false;
+                .map(|factory| Path::new(factory).resolve())
+                .any(|factory| *factory == import_path);
         }
 
         // Lax rules for built-in factories (we look at prefix to handle patronum/*)


### PR DESCRIPTION
- Convert all paths to use `"/"` as separator to improve compatibility with Windows.
- Always remove `cwd` from `filename` to ensure that the relative path to the current file is used for detecting factories.