### PR TITLE
Support for Hot Module Replacement

### DIFF
--- a/.changeset/friendly-keys-wink.md
+++ b/.changeset/friendly-keys-wink.md
@@ -1,0 +1,5 @@
+---
+"@effector/swc-plugin": minor
+---
+
+Support for Hot Module Replacement

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,9 @@ pub struct Config {
     pub debug_sids: bool,
 
     #[serde(default)]
+    pub hmr: HotReplacementMode,
+
+    #[serde(default)]
     pub factories: Vec<String>,
 
     #[serde(
@@ -26,7 +29,6 @@ pub struct Config {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ForceScopeConfig {
     #[serde(default = "Configurator::enabled")]
     hooks: bool,
@@ -62,6 +64,19 @@ impl Default for ForceScope {
     fn default() -> Self {
         Self::Simple(false)
     }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
+pub enum HotReplacementMode {
+    #[serde(rename = "es")]
+    ImportMeta,
+
+    #[serde(rename = "cjs")]
+    Module,
+
+    #[default]
+    #[serde(rename = "none")]
+    None,
 }
 
 struct Configurator;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
 #[repr(usize)]
 pub enum EffectorMethod {
     // unit creators
@@ -18,6 +18,9 @@ pub enum EffectorMethod {
     Attach,
     Split,
     CreateApi,
+
+    // effector factory
+    Factory,
 
     // view library hooks
     UseEvent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,9 @@ use swc_core::{
 
 pub use crate::{config::Config, visitors::VisitorMeta};
 use crate::{
+    config::HotReplacementMode,
     utils::path::filename_from_meta,
-    visitors::{analyzer, force_scope, unit_identifier},
+    visitors::{analyzer, force_scope, hmr, unit_identifier},
 };
 
 mod config;
@@ -44,6 +45,10 @@ pub fn effector(meta: VisitorMeta) -> impl VisitMut + Fold {
             visitor: force_scope::hooks(&meta),
         },
         unit_identifier(&meta),
+        Optional {
+            enabled: config.hmr != HotReplacementMode::None,
+            visitor: hmr(&meta),
+        },
     );
 
     as_folder(visitor)
@@ -64,6 +69,10 @@ pub fn effector(meta: VisitorMeta) -> impl VisitMut + Pass {
             visitor: force_scope::hooks(&meta),
         },
         unit_identifier(&meta),
+        Optional {
+            enabled: config.hmr != HotReplacementMode::None,
+            visitor: hmr(&meta),
+        },
     );
 
     visit_mut_pass(chain)

--- a/src/utils/import.rs
+++ b/src/utils/import.rs
@@ -1,0 +1,14 @@
+use swc_core::ecma::ast::*;
+
+pub(crate) trait Imported {
+    fn as_known(&self) -> &str;
+}
+
+impl Imported for ImportNamedSpecifier {
+    fn as_known(&self) -> &str {
+        self.imported
+            .as_ref()
+            .map(|export| export.atom())
+            .unwrap_or(&self.local.sym)
+    }
+}

--- a/src/utils/matcher.rs
+++ b/src/utils/matcher.rs
@@ -1,0 +1,54 @@
+use std::rc::Rc;
+
+use swc_core::ecma::ast::*;
+
+use crate::{
+    Config,
+    constants::EffectorMethod,
+    state::EffectorImport,
+    utils::method::{to_domain_method, to_method},
+    visitors::{MutableState, VisitorMeta},
+};
+
+pub(crate) struct EffectorMatcher {
+    pub config: Rc<Config>,
+    pub state:  MutableState,
+}
+
+impl EffectorMatcher {
+    pub fn from_meta(meta: &VisitorMeta) -> Self {
+        Self { config: meta.config.clone(), state: meta.state.clone() }
+    }
+
+    pub fn try_match(&self, node: &Expr) -> Option<EffectorMethod> {
+        match node {
+            Expr::Ident(ident) => {
+                self.state.borrow().aliases.get(&ident.to_id()).copied()
+            }
+            Expr::Member(member) => {
+                let MemberExpr { obj, prop, .. } = member;
+                let (obj, prop) = (obj.as_ident()?, prop.as_ident()?);
+
+                if self.is_effector(&obj.to_id()) {
+                    to_method(&prop.sym)
+                } else if self.config.transform_domain_methods {
+                    to_domain_method(&prop.sym)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn track(&mut self, id: Id, method: EffectorMethod) {
+        self.state.borrow_mut().aliases.insert(id, method);
+    }
+
+    fn is_effector(&self, id: &Id) -> bool {
+        let EffectorImport { star, def } = &self.state.borrow().import;
+
+        star.as_ref().is_some_and(|star| *star == *id)
+            || def.as_ref().is_some_and(|def| *def == *id)
+    }
+}

--- a/src/utils/method.rs
+++ b/src/utils/method.rs
@@ -30,6 +30,7 @@ pub(crate) fn to_method(name: &str) -> Option<EffectorMethod> {
         "reflect" => Some(EffectorMethod::Reflect),
         "list" => Some(EffectorMethod::ReflectList),
         "variant" => Some(EffectorMethod::ReflectVariant),
+
         _ => None,
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,12 @@
-pub(crate) use self::method::{to_domain_method, to_method};
-pub use self::{keyof::*, path::Resolve, uobject::UObject};
+pub(crate) use self::{
+    import::Imported, keyof::*, matcher::EffectorMatcher, method::to_method,
+    path::Resolve, unique::UniqueId, uobject::UObject,
+};
 
+mod import;
 mod keyof;
+mod matcher;
 mod method;
 pub(crate) mod path;
+mod unique;
 mod uobject;

--- a/src/utils/unique.rs
+++ b/src/utils/unique.rs
@@ -1,0 +1,12 @@
+use swc_core::ecma::{ast::Ident, utils::private_ident};
+
+pub(crate) struct UniqueId;
+
+impl UniqueId {
+    const PREFIX: &str = "_effector$";
+
+    pub fn ident(name: &str) -> Ident {
+        let id = Self::PREFIX.to_owned();
+        private_ident!(id + name)
+    }
+}

--- a/src/visitors/analyzer.rs
+++ b/src/visitors/analyzer.rs
@@ -5,7 +5,7 @@ use swc_core::ecma::{ast::*, visit::VisitMut};
 use crate::{
     Config,
     constants::INTERNAL,
-    utils::{Resolve, to_method},
+    utils::{Imported, Resolve, to_method},
     visitors::{MutableState, VisitorMeta},
 };
 
@@ -24,17 +24,6 @@ pub(crate) fn analyzer(meta: &VisitorMeta) -> impl VisitMut + use<> {
 }
 
 impl Analyzer {
-    fn name_of(import: &ImportNamedSpecifier) -> &str {
-        import
-            .imported
-            .as_ref()
-            .map(|v| match v {
-                ModuleExportName::Ident(v) => &*v.sym,
-                ModuleExportName::Str(v) => &*v.value,
-            })
-            .unwrap_or(&*import.local.sym)
-    }
-
     fn is_factory(&self, import: &String) -> bool {
         let is_relative = import.starts_with("./") || import.starts_with("../");
 
@@ -83,7 +72,7 @@ impl Analyzer {
 
         match specifier {
             ImportSpecifier::Named(import) => {
-                if let Some(method) = to_method(Self::name_of(import)) {
+                if let Some(method) = to_method(import.as_known()) {
                     state.aliases.insert(import.local.to_id(), method);
                 }
             }

--- a/src/visitors/force_scope/hooks.rs
+++ b/src/visitors/force_scope/hooks.rs
@@ -45,6 +45,7 @@ impl ForceHooksScope {
 
     fn inject_use_store_map(&self, node: &mut CallExpr) {
         match &mut node.args[..] {
+            #[rustfmt::skip]
             [
                 ExprOrSpread { spread: None, expr: store },
                 ExprOrSpread { spread: None, expr: func },

--- a/src/visitors/hmr/finder.rs
+++ b/src/visitors/hmr/finder.rs
@@ -1,0 +1,82 @@
+use swc_core::ecma::{
+    ast::*,
+    visit::{Visit, VisitWith},
+};
+
+use crate::{constants::EffectorMethod, utils::EffectorMatcher};
+
+const CALLS: [EffectorMethod; 14] = [
+    EffectorMethod::Store,
+    EffectorMethod::Event,
+    EffectorMethod::Effect,
+    EffectorMethod::Merge,
+    EffectorMethod::Restore,
+    EffectorMethod::Combine,
+    EffectorMethod::Sample,
+    EffectorMethod::Forward,
+    EffectorMethod::Guard,
+    EffectorMethod::Attach,
+    EffectorMethod::Split,
+    EffectorMethod::CreateApi,
+    EffectorMethod::Gate,
+    EffectorMethod::Factory,
+];
+
+const METHODS: [&str; 8] = [
+    "map",
+    "filter",
+    "filterMap",
+    "subscribe",
+    "on",
+    "watch",
+    "reset",
+    "prepend",
+];
+
+pub struct CallFinder<'a> {
+    matcher: &'a EffectorMatcher,
+
+    found: bool,
+}
+
+impl<'a> CallFinder<'a> {
+    pub fn new(matcher: &'a EffectorMatcher) -> Self {
+        Self { matcher, found: false }
+    }
+
+    pub fn is_found(&self) -> bool {
+        self.found
+    }
+
+    fn is_method(&self, expr: &Expr) -> bool {
+        let Expr::Member(member) = expr else { return false };
+        let MemberProp::Ident(ref ident) = member.prop else { return false };
+
+        METHODS.contains(&ident.sym.as_str())
+    }
+
+    fn is_call(&self, expr: &Expr) -> bool {
+        let Some(method) = self.matcher.try_match(expr) else { return false };
+
+        CALLS.contains(&method)
+    }
+}
+
+impl Visit for CallFinder<'_> {
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
+    fn visit_function(&mut self, _: &Function) {}
+    fn visit_class(&mut self, _: &Class) {}
+
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        if self.found {
+            return /* stop traversal */;
+        };
+
+        let Callee::Expr(expr) = &node.callee else { return };
+        self.found = self.is_call(expr) || self.is_method(expr);
+
+        if !self.found {
+            node.visit_children_with(self);
+        }
+    }
+}

--- a/src/visitors/hmr/mod.rs
+++ b/src/visitors/hmr/mod.rs
@@ -1,0 +1,152 @@
+use std::rc::Rc;
+
+use swc_core::{
+    common::{Span, util::take::Take},
+    ecma::{
+        ast::*,
+        utils::ExprFactory,
+        visit::{VisitMut, VisitMutWith, VisitWith, noop_visit_mut_type},
+    },
+    quote,
+};
+use tools::HmrToolMap;
+
+use self::{finder::CallFinder, tools::HmrTool};
+use crate::{
+    config::{Config, HotReplacementMode},
+    utils::{EffectorMatcher, UniqueId},
+    visitors::VisitorMeta,
+};
+
+mod finder;
+mod tools;
+
+const REGION: &str = "region";
+
+struct HotModuleReplacer {
+    tools: HmrToolMap,
+
+    matcher: EffectorMatcher,
+
+    region: Option<Ident>,
+    config: Rc<Config>,
+}
+
+pub(crate) fn hmr(meta: &VisitorMeta) -> impl VisitMut + use<> {
+    HotModuleReplacer {
+        tools: HmrToolMap::new(),
+
+        matcher: EffectorMatcher::from_meta(meta),
+
+        region: None,
+        config: meta.config.clone(),
+    }
+}
+
+impl HotModuleReplacer {
+    fn create_import(&mut self) -> ModuleItem {
+        let specifiers: Vec<_> = HmrTool::LIST
+            .iter()
+            .map(|tool| (self.tools.get(tool).clone(), tool.as_str()))
+            .map(|(local, imported)| ImportNamedSpecifier {
+                local: local.into(),
+                imported: Some(Ident::from(imported).into()),
+                span: Span::dummy(),
+                is_type_only: false,
+            })
+            .map(ImportSpecifier::Named)
+            .collect();
+
+        let mut import = quote!("import {} from 'effector'" as ModuleItem);
+
+        import
+            .as_mut_module_decl()
+            .and_then(|module| module.as_mut_import())
+            .unwrap()
+            .specifiers = specifiers;
+
+        import
+    }
+
+    fn create_region(&mut self) -> ModuleItem {
+        let id = self.region.as_ref().unwrap();
+
+        self.tools
+            .get(&HmrTool::CreateNode)
+            .clone()
+            .as_call(Span::dummy(), Vec::dummy())
+            .into_var_decl(VarDeclKind::Const, id.clone().into())
+            .into()
+    }
+
+    fn create_dispose(&mut self) -> ModuleItem {
+        let handler = quote!("() => $clear($region)" as Expr,
+            clear: Ident = self.tools.get(&HmrTool::ClearNode).clone().into(),
+            region: Ident = self.region.clone().unwrap()
+        );
+
+        match self.config.hmr {
+            HotReplacementMode::Module => {
+                quote!("if (module.hot) module.hot.dispose($handler)" as ModuleItem, handler: Expr = handler)
+            }
+            HotReplacementMode::ImportMeta => {
+                quote!("if (import.meta.hot) import.meta.hot.dispose($handler)" as ModuleItem, handler: Expr = handler)
+            }
+            HotReplacementMode::None => unreachable!("visitor should not have run"),
+        }
+    }
+
+    fn wrap(&mut self, original: Expr) -> CallExpr {
+        let region = self.region.get_or_insert_with(|| UniqueId::ident(REGION));
+        let with = self.tools.get(&HmrTool::WithRegion);
+
+        quote!(
+            "$with($region, () => $original)" as Expr,
+            with: Ident = with.clone().into(),
+            region: Ident = region.clone(),
+            original: Expr = original
+        )
+        .expect_call()
+    }
+}
+
+impl VisitMut for HotModuleReplacer {
+    noop_visit_mut_type!();
+
+    fn visit_mut_module(&mut self, node: &mut Module) {
+        node.visit_mut_children_with(self);
+
+        if self.region.is_none() {
+            return;
+        };
+
+        let region = self.create_region();
+        let import = self.create_import();
+        let dispose = self.create_dispose();
+
+        let first_import = node
+            .body
+            .iter()
+            .position(|expr| matches!(expr, ModuleItem::ModuleDecl(..)))
+            .unwrap_or(0);
+
+        node.body.insert(first_import, region);
+        node.body.insert(first_import, import);
+
+        node.body.push(dispose);
+    }
+
+    fn visit_mut_arrow_expr(&mut self, _: &mut ArrowExpr) {}
+    fn visit_mut_function(&mut self, _: &mut Function) {}
+    fn visit_mut_class(&mut self, _: &mut Class) {}
+
+    fn visit_mut_call_expr(&mut self, node: &mut CallExpr) {
+        let mut finder = CallFinder::new(&self.matcher);
+
+        node.visit_with(&mut finder);
+
+        if finder.is_found() {
+            *node = self.wrap(node.take().into());
+        }
+    }
+}

--- a/src/visitors/hmr/tools.rs
+++ b/src/visitors/hmr/tools.rs
@@ -1,0 +1,48 @@
+use swc_core::ecma::ast::Id;
+
+use crate::utils::UniqueId;
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+pub(super) enum HmrTool {
+    WithRegion,
+    ClearNode,
+    CreateNode,
+}
+
+impl HmrTool {
+    const SPECIFIERS: [&'static str; 3] = ["withRegion", "clearNode", "createNode"];
+
+    pub const LIST: [HmrTool; 3] =
+        [HmrTool::WithRegion, HmrTool::ClearNode, HmrTool::CreateNode];
+
+    pub fn as_str(&self) -> &'static str {
+        Self::SPECIFIERS[*self as usize]
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct HmrToolMap {
+    pub region: Id,
+    pub clear:  Id,
+    pub create: Id,
+}
+
+impl HmrToolMap {
+    pub fn get(&self, tool: &HmrTool) -> &Id {
+        match tool {
+            HmrTool::WithRegion => &self.region,
+            HmrTool::ClearNode => &self.clear,
+            HmrTool::CreateNode => &self.create,
+        }
+    }
+
+    pub fn new() -> Self {
+        let ident = |tool: HmrTool| UniqueId::ident(tool.as_str()).to_id();
+
+        Self {
+            region: ident(HmrTool::WithRegion),
+            clear:  ident(HmrTool::ClearNode),
+            create: ident(HmrTool::CreateNode),
+        }
+    }
+}

--- a/src/visitors/mod.rs
+++ b/src/visitors/mod.rs
@@ -1,7 +1,8 @@
 pub use self::meta::{MutableState, VisitorMeta};
-pub(crate) use self::{analyzer::analyzer, sid::unit_identifier};
+pub(crate) use self::{analyzer::analyzer, hmr::hmr, sid::unit_identifier};
 
 mod analyzer;
 pub mod force_scope;
+mod hmr;
 mod meta;
 mod sid;

--- a/src/visitors/sid/factory.rs
+++ b/src/visitors/sid/factory.rs
@@ -7,7 +7,7 @@ use swc_core::{
 use super::call_identity::CallIdentity;
 use crate::{Config, utils::UObject};
 
-pub(super) const WITH_FACTORY: &str = "_effector$factory";
+pub(super) const WITH_FACTORY: &str = "factory";
 
 pub(super) struct FactoryTransformer<'a> {
     pub mapper: &'a dyn SourceMapper,

--- a/tests/fixtures/hmr/disabled/config.json
+++ b/tests/fixtures/hmr/disabled/config.json
@@ -1,0 +1,4 @@
+{
+  "hmr": "none",
+  "addNames": false
+}

--- a/tests/fixtures/hmr/disabled/input.js
+++ b/tests/fixtures/hmr/disabled/input.js
@@ -1,0 +1,3 @@
+import { createEvent } from "effector";
+
+const decrement = createEvent();

--- a/tests/fixtures/hmr/disabled/output.js
+++ b/tests/fixtures/hmr/disabled/output.js
@@ -1,0 +1,4 @@
+import { createEvent } from "effector";
+const decrement = createEvent({
+    sid: "9n8uzlgk"
+});

--- a/tests/fixtures/hmr/edge-class/config.json
+++ b/tests/fixtures/hmr/edge-class/config.json
@@ -1,0 +1,4 @@
+{
+  "hmr": "es",
+  "addNames": false
+}

--- a/tests/fixtures/hmr/edge-class/input.js
+++ b/tests/fixtures/hmr/edge-class/input.js
@@ -1,0 +1,5 @@
+import { createEvent } from "effector";
+
+export default class Class {
+  event = createEvent();
+}

--- a/tests/fixtures/hmr/edge-class/output.js
+++ b/tests/fixtures/hmr/edge-class/output.js
@@ -1,0 +1,6 @@
+import { createEvent } from "effector";
+export default class Class {
+    event = createEvent({
+        sid: "7y0i70wh"
+    });
+}

--- a/tests/fixtures/hmr/edge-nested/config.json
+++ b/tests/fixtures/hmr/edge-nested/config.json
@@ -1,0 +1,4 @@
+{
+  "hmr": "cjs",
+  "addNames": false
+}

--- a/tests/fixtures/hmr/edge-nested/input.js
+++ b/tests/fixtures/hmr/edge-nested/input.js
@@ -1,0 +1,13 @@
+import { sample, createStore, createEvent } from "effector"
+
+const $count = createStore(0)
+const increment = createEvent()
+
+if (true) {
+  sample({
+    clock: increment,
+    source: $count,
+    fn: (count) => count + 1,
+    target: $count,
+  })
+}

--- a/tests/fixtures/hmr/edge-nested/output.js
+++ b/tests/fixtures/hmr/edge-nested/output.js
@@ -1,0 +1,25 @@
+import { withRegion as _effector$withRegion, clearNode as _effector$clearNode, createNode as _effector$createNode } from 'effector';
+const _effector$region = _effector$createNode();
+import { sample, createStore, createEvent } from "effector";
+const $count = _effector$withRegion(_effector$region, ()=>createStore(0, {
+        sid: "8iyytmbq"
+    }));
+const increment = _effector$withRegion(_effector$region, ()=>createEvent({
+        sid: "djprtr5t"
+    }));
+if (true) {
+    _effector$withRegion(_effector$region, ()=>sample({
+            and: [
+                {
+                    clock: increment,
+                    source: $count,
+                    fn: (count)=>count + 1,
+                    target: $count
+                }
+            ],
+            or: {
+                sid: "7bpxss3h"
+            }
+        }));
+}
+if (module.hot) module.hot.dispose(()=>_effector$clearNode(_effector$region));

--- a/tests/fixtures/hmr/exports/config.json
+++ b/tests/fixtures/hmr/exports/config.json
@@ -1,0 +1,4 @@
+{
+  "hmr": "es",
+  "addNames": false
+}

--- a/tests/fixtures/hmr/exports/input.js
+++ b/tests/fixtures/hmr/exports/input.js
@@ -1,0 +1,13 @@
+import { createEvent, createStore, createEffect } from "effector";
+import { invoke } from "@withease/factories";
+
+export var $var
+
+export const $store = createStore("");
+export let effectFx = createEffect();
+
+export default createEvent();
+
+export const $$model = invoke(() => ({ event: createEvent() }));
+
+$var = createStore(0)

--- a/tests/fixtures/hmr/exports/output.js
+++ b/tests/fixtures/hmr/exports/output.js
@@ -1,0 +1,27 @@
+import { withRegion as _effector$withRegion, clearNode as _effector$clearNode, createNode as _effector$createNode } from 'effector';
+const _effector$region = _effector$createNode();
+import { withFactory as _effector$factory } from 'effector';
+import { createEvent, createStore, createEffect } from "effector";
+import { invoke } from "@withease/factories";
+export var $var;
+export const $store = _effector$withRegion(_effector$region, ()=>createStore("", {
+        sid: "a0qxuyf0"
+    }));
+export let effectFx = _effector$withRegion(_effector$region, ()=>createEffect({
+        sid: "d5v00uhy"
+    }));
+export default _effector$withRegion(_effector$region, ()=>createEvent({
+        sid: "70k1qbs7"
+    }));
+export const $$model = _effector$withRegion(_effector$region, ()=>_effector$factory({
+        sid: "biutajoy",
+        fn: ()=>invoke(()=>({
+                    event: createEvent({
+                        sid: "c4g1bbvz"
+                    })
+                }))
+    }));
+$var = _effector$withRegion(_effector$region, ()=>createStore(0, {
+        sid: "33om66sn"
+    }));
+if (import.meta.hot) import.meta.hot.dispose(()=>_effector$clearNode(_effector$region));

--- a/tests/fixtures/hmr/factory/config.json
+++ b/tests/fixtures/hmr/factory/config.json
@@ -1,0 +1,4 @@
+{
+  "hmr": "cjs",
+  "addNames": false
+}

--- a/tests/fixtures/hmr/factory/input.js
+++ b/tests/fixtures/hmr/factory/input.js
@@ -1,0 +1,27 @@
+import { createEvent, createStore, createEffect } from "effector";
+import { invoke, createFactory } from "@withease/factories"
+
+const correct = createFactory(() => {
+  const $si = createStore(0);
+  const ei = createEvent();
+  const iFx = createEffect(() => {});
+
+  return { $si, ei, iFx };
+});
+
+function incorrect() {
+  const $si = createStore(0);
+  const ei = createEvent();
+  const iFx = createEffect(() => {});
+
+  return { $si, ei, iFx };
+}
+
+const arrow = () => createStore(0);
+
+export const $$model = {
+  correct: invoke(correct),
+  incorrect: incorrect(),
+
+  arrow: arrow(),
+};

--- a/tests/fixtures/hmr/factory/output.js
+++ b/tests/fixtures/hmr/factory/output.js
@@ -1,0 +1,52 @@
+import { withRegion as _effector$withRegion, clearNode as _effector$clearNode, createNode as _effector$createNode } from 'effector';
+const _effector$region = _effector$createNode();
+import { withFactory as _effector$factory } from 'effector';
+import { createEvent, createStore, createEffect } from "effector";
+import { invoke, createFactory } from "@withease/factories";
+const correct = _effector$withRegion(_effector$region, ()=>_effector$factory({
+        sid: "2892eeus",
+        fn: ()=>createFactory(()=>{
+                const $si = createStore(0, {
+                    sid: "4pb4z0y3"
+                });
+                const ei = createEvent({
+                    sid: "8h86066l"
+                });
+                const iFx = createEffect(()=>{}, {
+                    sid: "bs7fi7aq"
+                });
+                return {
+                    $si,
+                    ei,
+                    iFx
+                };
+            })
+    }));
+function incorrect() {
+    const $si = createStore(0, {
+        sid: "4b0txldm"
+    });
+    const ei = createEvent({
+        sid: "7qs8axzo"
+    });
+    const iFx = createEffect(()=>{}, {
+        sid: "a9h6o4rv"
+    });
+    return {
+        $si,
+        ei,
+        iFx
+    };
+}
+const arrow = ()=>createStore(0, {
+        sid: "gbyi551"
+    });
+export const $$model = {
+    correct: _effector$withRegion(_effector$region, ()=>_effector$factory({
+            sid: "bz30rfup",
+            fn: ()=>invoke(correct)
+        })),
+    incorrect: incorrect(),
+    arrow: arrow()
+};
+if (module.hot) module.hot.dispose(()=>_effector$clearNode(_effector$region));

--- a/tests/fixtures/hmr/methods/config.json
+++ b/tests/fixtures/hmr/methods/config.json
@@ -1,0 +1,4 @@
+{
+  "hmr": "cjs",
+  "addNames": false
+}

--- a/tests/fixtures/hmr/methods/input.js
+++ b/tests/fixtures/hmr/methods/input.js
@@ -1,0 +1,16 @@
+import { createStore, createEvent } from "effector"
+
+const $count = createStore(0)
+const update = createEvent()
+const reset = createEvent()
+
+const $isOdd = $count.map(count => count % 2 == 1)
+
+const decrement = update.prepend(() => -1)
+const incremented = update.filter({ fn: (v) => v > 0 })
+
+$count.on(update, (count, diff) => count + diff);
+
+const $same = $count.on($isOdd.updates, (count) => count + 1).reset(reset)
+
+$count.watch(console.log);

--- a/tests/fixtures/hmr/methods/output.js
+++ b/tests/fixtures/hmr/methods/output.js
@@ -1,0 +1,21 @@
+import { withRegion as _effector$withRegion, clearNode as _effector$clearNode, createNode as _effector$createNode } from 'effector';
+const _effector$region = _effector$createNode();
+import { createStore, createEvent } from "effector";
+const $count = _effector$withRegion(_effector$region, ()=>createStore(0, {
+        sid: "8iyytmbq"
+    }));
+const update = _effector$withRegion(_effector$region, ()=>createEvent({
+        sid: "262s37yl"
+    }));
+const reset = _effector$withRegion(_effector$region, ()=>createEvent({
+        sid: "67l5wce4"
+    }));
+const $isOdd = _effector$withRegion(_effector$region, ()=>$count.map((count)=>count % 2 == 1));
+const decrement = _effector$withRegion(_effector$region, ()=>update.prepend(()=>-1));
+const incremented = _effector$withRegion(_effector$region, ()=>update.filter({
+        fn: (v)=>v > 0
+    }));
+_effector$withRegion(_effector$region, ()=>$count.on(update, (count, diff)=>count + diff));
+const $same = _effector$withRegion(_effector$region, ()=>$count.on($isOdd.updates, (count)=>count + 1).reset(reset));
+_effector$withRegion(_effector$region, ()=>$count.watch(console.log));
+if (module.hot) module.hot.dispose(()=>_effector$clearNode(_effector$region));

--- a/tests/fixtures/hmr/regular/config.json
+++ b/tests/fixtures/hmr/regular/config.json
@@ -1,0 +1,4 @@
+{
+  "hmr": "cjs",
+  "addNames": false
+}

--- a/tests/fixtures/hmr/regular/input.js
+++ b/tests/fixtures/hmr/regular/input.js
@@ -1,0 +1,29 @@
+import {
+  createEvent,
+  createStore,
+  sample,
+  createEffect,
+  attach,
+  forward,
+} from "effector";
+
+const decrement = createEvent();
+
+const $count = createStore(0);
+
+const fx = createEffect(() => {});
+const attachedFx = attach({ effect: fx });
+
+const $store = sample({ clock: $count });
+
+sample({
+  clock: decrement,
+  source: $store,
+  fn: (count) => count - 1,
+  target: $count,
+});
+
+forward({
+  clock: $store.updates,
+  target: attachedFx,
+});

--- a/tests/fixtures/hmr/regular/output.js
+++ b/tests/fixtures/hmr/regular/output.js
@@ -1,0 +1,53 @@
+import { withRegion as _effector$withRegion, clearNode as _effector$clearNode, createNode as _effector$createNode } from 'effector';
+const _effector$region = _effector$createNode();
+import { createEvent, createStore, sample, createEffect, attach, forward } from "effector";
+const decrement = _effector$withRegion(_effector$region, ()=>createEvent({
+        sid: "4koojyr"
+    }));
+const $count = _effector$withRegion(_effector$region, ()=>createStore(0, {
+        sid: "9srhzoiy"
+    }));
+const fx = _effector$withRegion(_effector$region, ()=>createEffect(()=>{}, {
+        sid: "80wcg0gv"
+    }));
+const attachedFx = _effector$withRegion(_effector$region, ()=>attach({
+        and: {
+            effect: fx
+        },
+        or: {
+            sid: "5tasuy4i"
+        }
+    }));
+const $store = _effector$withRegion(_effector$region, ()=>sample({
+        and: [
+            {
+                clock: $count
+            }
+        ],
+        or: {
+            sid: "32ttleyt"
+        }
+    }));
+_effector$withRegion(_effector$region, ()=>sample({
+        and: [
+            {
+                clock: decrement,
+                source: $store,
+                fn: (count)=>count - 1,
+                target: $count
+            }
+        ],
+        or: {
+            sid: "1fuuxs6f"
+        }
+    }));
+_effector$withRegion(_effector$region, ()=>forward({
+        and: {
+            clock: $store.updates,
+            target: attachedFx
+        },
+        or: {
+            sid: "9txefa7a"
+        }
+    }));
+if (module.hot) module.hot.dispose(()=>_effector$clearNode(_effector$region));

--- a/tests/fixtures/hmr/skip/config.json
+++ b/tests/fixtures/hmr/skip/config.json
@@ -1,0 +1,4 @@
+{
+  "hmr": "es",
+  "addNames": false
+}

--- a/tests/fixtures/hmr/skip/input.js
+++ b/tests/fixtures/hmr/skip/input.js
@@ -1,0 +1,3 @@
+import { stuff } from "library";
+
+export const Stuff = stuff();

--- a/tests/fixtures/hmr/skip/output.js
+++ b/tests/fixtures/hmr/skip/output.js
@@ -1,0 +1,2 @@
+import { stuff } from "library";
+export const Stuff = stuff();


### PR DESCRIPTION
Adds support for Hot Module Replacement in bundlers that use either `import.meta.hot` (Vite) or `module.hot` (Webpack or Next)

#### Config

```ts
[
  "@effector/swc-plguin",
  {
    "hmr"?: "es" | "cjs" | "none"
  }
]
```

Tracking issue: https://github.com/effector/effector/issues/674

Babel Plugin reference implementation:
- https://github.com/effector/effector/pull/1235
- https://github.com/effector/effector/pull/1236