### PR TITLE
Support HMR in ESM mode in webpack and rspack

### DIFF
--- a/.changeset/eager-pants-kiss.md
+++ b/.changeset/eager-pants-kiss.md
@@ -1,0 +1,5 @@
+---
+"@effector/swc-plugin": patch
+---
+
+Add support for webpack ESM HMR using import.meta.webpackHot

--- a/src/visitors/hmr/mod.rs
+++ b/src/visitors/hmr/mod.rs
@@ -92,7 +92,7 @@ impl HotModuleReplacer {
                 quote!("if (module.hot) module.hot.dispose($handler)" as ModuleItem, handler: Expr = handler)
             }
             HotReplacementMode::ImportMeta => {
-                quote!("if (import.meta.hot) import.meta.hot.dispose($handler)" as ModuleItem, handler: Expr = handler)
+                quote!("if (import.meta.hot || import.meta.webpackHot) (import.meta.hot || import.meta.webpackHot).dispose($handler)" as ModuleItem, handler: Expr = handler)
             }
             HotReplacementMode::Disabled => unreachable!("visitor should not have run"),
             HotReplacementMode::Detect => unreachable!("detection is not supported"),

--- a/tests/fixtures/hmr/exports/output.js
+++ b/tests/fixtures/hmr/exports/output.js
@@ -26,4 +26,4 @@ export const $$model = _effector$withRegion(_effector$region, ()=>_effector$fact
 $var = _effector$withRegion(_effector$region, ()=>createStore(0, {
         sid: "33om66sn"
     }));
-if (import.meta.hot) import.meta.hot.dispose(()=>_effector$clearNode(_effector$region));
+if (import.meta.hot || import.meta.webpackHot) (import.meta.hot || import.meta.webpackHot).dispose(()=>_effector$clearNode(_effector$region));


### PR DESCRIPTION
`import.meta.webpackHot` supported by rspack https://rspack.rs/api/runtime-api/hmr#example
and webpack https://webpack.js.org/api/hot-module-replacement/

Babel plugin already works in same way https://github.com/effector/effector/blob/469efb2ef203283857e76efd4836cb718b4d9014/src/babel/plugin/templates.ts#L72