### PR TITLE
Add missing factories from babel plugin

### DIFF
--- a/.changeset/dry-boxes-swim.md
+++ b/.changeset/dry-boxes-swim.md
@@ -1,0 +1,5 @@
+---
+"@effector/swc-plugin": patch
+---
+
+Add `@effector/reflect`, `@effector/reflect/ssr` and `@effector/reflect/scope` to default factories

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -40,7 +40,7 @@ pub enum EffectorMethod {
 
 pub(crate) struct Internal {
     pub tracked:   [&'static str; 10],
-    pub factories: [&'static str; 5],
+    pub factories: [&'static str; 8],
 }
 
 pub(crate) static INTERNAL: Internal = Internal::new();
@@ -72,6 +72,9 @@ impl Internal {
                 "effector-action",
                 "@farfetched/core",
                 "@withease/factories",
+                "@effector/reflect",
+                "@effector/reflect/ssr",
+                "@effector/reflect/scope",
             ],
         }
     }

--- a/tests/fixtures/nextjs/use_client/output.js
+++ b/tests/fixtures/nextjs/use_client/output.js
@@ -1,17 +1,28 @@
 "use client";
+import { withFactory as _effector$factory } from 'effector';
 import { reflect, variant } from "@effector/reflect";
 import { BreweryCard, Loader } from "#root/shared/ui";
 import { $breweryOfTheDay } from "./model";
-export const BreweryOfTheDay = variant({
-    if: $breweryOfTheDay.map((brewery)=>!!brewery),
-    then: reflect({
-        view: BreweryCard,
-        bind: {
-            name: $breweryOfTheDay.map((brewery)=>brewery?.name ?? "Unknown"),
-            brewery_type: $breweryOfTheDay.map((brewery)=>brewery?.brewery_type ?? "nano"),
-            website_url: $breweryOfTheDay.map((brewery)=>brewery?.website_url ?? null),
-            image: $breweryOfTheDay.map((brewery)=>brewery?.image ?? "")
-        }
-    }),
-    else: Loader
+export const BreweryOfTheDay = _effector$factory({
+    sid: "1k46jcja",
+    name: "BreweryOfTheDay",
+    method: "variant",
+    fn: ()=>variant({
+            if: $breweryOfTheDay.map((brewery)=>!!brewery),
+            then: _effector$factory({
+                sid: "5uxnyvvo",
+                name: "then",
+                method: "reflect",
+                fn: ()=>reflect({
+                        view: BreweryCard,
+                        bind: {
+                            name: $breweryOfTheDay.map((brewery)=>brewery?.name ?? "Unknown"),
+                            brewery_type: $breweryOfTheDay.map((brewery)=>brewery?.brewery_type ?? "nano"),
+                            website_url: $breweryOfTheDay.map((brewery)=>brewery?.website_url ?? null),
+                            image: $breweryOfTheDay.map((brewery)=>brewery?.image ?? "")
+                        }
+                    })
+            }),
+            else: Loader
+        })
 });

--- a/tests/fixtures/view/force_scope/hooks_only/output.js
+++ b/tests/fixtures/view/force_scope/hooks_only/output.js
@@ -1,12 +1,18 @@
+import { withFactory as _effector$factory } from 'effector';
 import { useUnit } from "effector-react";
 import { reflect } from "@effector/reflect";
 // --- reflect/disabled ---
-const Name = reflect({
-    view: Input,
-    bind: {
-        value: $name,
-        placeholder: "Name"
-    }
+const Name = _effector$factory({
+    sid: "2qq0v05m",
+    name: "Name",
+    method: "reflect",
+    fn: ()=>reflect({
+            view: Input,
+            bind: {
+                value: $name,
+                placeholder: "Name"
+            }
+        })
 });
 // --- useUnit/enabled ---
 useUnit($name, {

--- a/tests/fixtures/view/force_scope/reflect/output.js
+++ b/tests/fixtures/view/force_scope/reflect/output.js
@@ -1,78 +1,109 @@
+import { withFactory as _effector$factory } from 'effector';
 import { reflect, list, variant } from "@effector/reflect";
 // === reflect: insert ===
 // --- reflect ---
-const Name = reflect({
-    view: Input,
-    bind: {
-        value: $name,
-        placeholder: "Name"
-    },
-    useUnitConfig: {
-        forceScope: true
-    }
+const Name = _effector$factory({
+    sid: "2qq0v05m",
+    name: "Name",
+    method: "reflect",
+    fn: ()=>reflect({
+            view: Input,
+            bind: {
+                value: $name,
+                placeholder: "Name"
+            },
+            useUnitConfig: {
+                forceScope: true
+            }
+        })
 });
 // --- variant ---
-const Field = variant({
-    source: $fieldType,
-    bind: {
-        onChange: valueChanged,
-        value: $value
-    },
-    cases: {
-        date: DateSelector,
-        number: ()=>null
-    },
-    default: TextInput,
-    useUnitConfig: {
-        forceScope: true
-    }
+const Field = _effector$factory({
+    sid: "tcdbiwi",
+    name: "Field",
+    method: "variant",
+    fn: ()=>variant({
+            source: $fieldType,
+            bind: {
+                onChange: valueChanged,
+                value: $value
+            },
+            cases: {
+                date: DateSelector,
+                number: ()=>null
+            },
+            default: TextInput,
+            useUnitConfig: {
+                forceScope: true
+            }
+        })
 });
 // --- list ---
-const Items = list({
-    view: Item,
-    source: $users,
-    bind: {
-        color: $color
-    },
-    mapItem: {
-        id: (user)=>user.id,
-        name: (user)=>user.name
-    },
-    getKey: (user)=>`${user.id}${user.name}`,
-    useUnitConfig: {
-        forceScope: true
-    }
+const Items = _effector$factory({
+    sid: "b5a8z9yo",
+    name: "Items",
+    method: "list",
+    fn: ()=>list({
+            view: Item,
+            source: $users,
+            bind: {
+                color: $color
+            },
+            mapItem: {
+                id: (user)=>user.id,
+                name: (user)=>user.name
+            },
+            getKey: (user)=>`${user.id}${user.name}`,
+            useUnitConfig: {
+                forceScope: true
+            }
+        })
 });
 // === reflect: skip ===
 // --- reflect ---
-const NameInvalid = reflect({
-    view: Input,
-    bind: {
-        value: $name,
-        placeholder: "Name"
-    },
-    useUnitConfig: {}
+const NameInvalid = _effector$factory({
+    sid: "3ra7qbcp",
+    name: "NameInvalid",
+    method: "reflect",
+    fn: ()=>reflect({
+            view: Input,
+            bind: {
+                value: $name,
+                placeholder: "Name"
+            },
+            useUnitConfig: {}
+        })
 });
 // --- variant ---
-const FieldInvalid = variant({
-    source: $fieldType,
-    cases: {
-        date: DateSelector,
-        number: ()=>null
-    },
-    useUnitConfig: {
-        forceScope: false
-    }
-});
+const FieldInvalid = _effector$factory({
+    sid: "dtf5zm88",
+    name: "FieldInvalid",
+    method: "variant",
+    fn: ()=>variant({
+            source: $fieldType,
+            cases: {
+                date: DateSelector,
+                number: ()=>null
+            },
+            useUnitConfig: {
+                forceScope: false
+            }
+        })
+ });
 // --- list ---
-const ItemsInvalid = list({
-    view: Item,
-    source: $users,
-    bind: {
-        color: $color
-    },
-    getKey: (user)=>user.id,
-    useUnitConfig: {
-        forceScope: false
-    }
-});
+const ItemsInvalid = _effector$factory({
+    sid: "dm4l26wf",
+    name: "ItemsInvalid",
+    method: "list",
+    fn: ()=>list({
+            view: Item,
+            source: $users,
+            bind: {
+                color: $color
+            },
+            getKey: (user)=>user.id,
+            useUnitConfig: {
+                forceScope: false
+            }
+        })
+ });

--- a/tests/fixtures/view/force_scope/reflect_nested/output.js
+++ b/tests/fixtures/view/force_scope/reflect_nested/output.js
@@ -1,18 +1,29 @@
+import { withFactory as _effector$factory } from 'effector';
 import { reflect } from "@effector/reflect";
-const Reflected = reflect({
-    view: reflect({
-        view: Input,
-        bind: {
-            inner: $name
-        },
-        useUnitConfig: {
-            forceScope: true
-        }
-    }),
-    bind: {
-        outer: $name
-    },
-    useUnitConfig: {
-        forceScope: false
-    }
+const Reflected = _effector$factory({
+    sid: "dm21p9d0",
+    name: "Reflected",
+    method: "reflect",
+    fn: ()=>reflect({
+            view: _effector$factory({
+                sid: "atcsv5is",
+                name: "view",
+                method: "reflect",
+                fn: ()=>reflect({
+                        view: Input,
+                        bind: {
+                            inner: $name
+                        },
+                        useUnitConfig: {
+                            forceScope: true
+                        }
+                    })
+            }),
+            bind: {
+                outer: $name
+            },
+            useUnitConfig: {
+                forceScope: false
+            }
+        })
 });

--- a/tests/fixtures/view/force_scope/reflect_only/output.js
+++ b/tests/fixtures/view/force_scope/reflect_only/output.js
@@ -1,15 +1,21 @@
+import { withFactory as _effector$factory } from 'effector';
 import { useUnit } from "effector-react";
 import { reflect } from "@effector/reflect";
 // --- reflect/enabled ---
-const Name = reflect({
-    view: Input,
-    bind: {
-        value: $name,
-        placeholder: "Name"
-    },
-    useUnitConfig: {
-        forceScope: true
-    }
+const Name = _effector$factory({
+    sid: "2qq0v05m",
+    name: "Name",
+    method: "reflect",
+    fn: ()=>reflect({
+            view: Input,
+            bind: {
+                value: $name,
+                placeholder: "Name"
+            },
+            useUnitConfig: {
+                forceScope: true
+            }
+        })
 });
 // --- useUnit/disabled ---
 useUnit($name);


### PR DESCRIPTION
Babel plugin has `@effector/reflect` in default factories https://github.com/effector/effector/blob/469efb2ef203283857e76efd4836cb718b4d9014/src/babel/plugin/config.ts#L17-L19

But I am not really sure about changes in tests. 